### PR TITLE
Togglehue and customisable statuses

### DIFF
--- a/octoprint_octohue/__init__.py
+++ b/octoprint_octohue/__init__.py
@@ -90,24 +90,14 @@ class OctohuePlugin(octoprint.plugin.StartupPlugin,
 		if command == 'togglehue':
 			self.toggle_state()
 
-	# State to Light mappings
+	# Trigger state on Status match
 	def on_event(self, event, payload):
-		if event == "Connected":
+		if event in self._settings.get(["customstatus"]):
 			self._logger.info("Received Event: %s" % event)
-			self.rgb(self._settings.get(['connectedc']),bri=255)
-		if event == "Disconnected":
-			self._logger.info("Received Event: %s" % event)
-			self.set_state({"on": False})
-		if event == "PrinterStateChanged":
-			if payload['state_id'] == "PRINTING":
-				self._logger.info("New State: %s" % payload['state_id'])
-				self.rgb(self._settings.get(['connectedc']),bri=255)
-		if event == "PrintDone":
-			self._logger.info("Received Event: %s" % event)
-			self.rgb(self._settings.get(["completec"]))
-		if event == "PrintFailed":
-			self._logger.info("Received Event: %s" % event)
-			self.rgb(self._settings.get(["errorc"]))
+			if self._settings.get(['customstatus'])[event]['turnoff'] == False:
+				self.rgb(self._settings.get(['customstatus'])[event]['colour'],self._settings.get(['customstatus'])[event]['brightness'])
+			else:
+				self.set_state({"on": False})
 
 # General Octoprint Hooks Below
 
@@ -117,9 +107,41 @@ class OctohuePlugin(octoprint.plugin.StartupPlugin,
 			husername="",
 			lampid="",
 			lampisgroup="",
-			defaultbri="",
+			defaultbri=255,
 			offonshutdown=True,
 			showhuetoggle=True,
+			customstatus={
+				'Connected' : {
+					'colour':'#FFFFFF',
+					'brightness':'255',
+					'turnoff':False
+				},
+				'Disconnected': {
+					'colour':'',
+					'brightness':"",
+					'turnoff':True
+				},
+				'PrintStarted' : {
+					'colour':'#FFFFFF',
+					'brightness':'255',
+					'turnoff':False
+				},
+				'PrintResumed' : {
+					'colour':'#FFFFFF',
+					'brightness':'255',
+					'turnoff':False
+				},
+				'PrintDone': {
+					'colour':'#33FF36',
+					'brightness':'255',
+					'turnoff':False
+				},
+				'PrintFailed':{
+					'colour':'#FF0000',
+					'brightness':'255',
+					'turnoff':False
+				}
+			},
 			connectedc="#FFFFFF",
 			printingc="#FFFFFF",
 			completec="#33FF36",
@@ -139,6 +161,7 @@ class OctohuePlugin(octoprint.plugin.StartupPlugin,
 			defaultbri=self._settings.get(["defaultbri"]),
 			offonshutdown=self._settings.get(["offonshutdown"]),
 			showhuetoggle=self._settings.get(["showhuetoggle"]),
+			customstatus=self._settings.get(["customstatus"]),
 			connectedc=self._settings.get(["connectedc"]),
 			printingc=self._settings.get(["printingc"]),
 			completec=self._settings.get(["completec"]),
@@ -148,7 +171,8 @@ class OctohuePlugin(octoprint.plugin.StartupPlugin,
 	
 	def get_template_configs(self):
 		return [
-			dict(type="settings", custom_bindings=False)
+#			dict(type="navbar", custom_bindings=False),
+			dict(type="settings", custom_bindings=True)
 		]
 
 	##~~ AssetPlugin mixin

--- a/octoprint_octohue/__init__.py
+++ b/octoprint_octohue/__init__.py
@@ -48,12 +48,26 @@ class OctohuePlugin(octoprint.plugin.StartupPlugin,
 		
 		return self.set_state(state)
 
+	def get_state(self):
+		if self._settings.get(['lampisgroup']) == True:
+			self._state = self.pbridge.groups[self._settings.get(['lampid'])]().get("action")['on']
+		else:
+			self._state = self.pbridge.lights[self._settings.get(['lampid'])]().get("state")['on']
+		self._logger.debug("Get State is %s" % self._state )
+		return self._state
+
 	def set_state(self, state):
-		self._logger.info("Setting lampid: %s  Is Group: %s with State: %s" % (self._settings.get(['lampid']),self._settings.get(['lampisgroup']), state))
+		self._logger.debug("Setting lampid: %s  Is Group: %s with State: %s" % (self._settings.get(['lampid']),self._settings.get(['lampisgroup']), state))
 		if self._settings.get(['lampisgroup']) == True:
 			self.pbridge.groups[self._settings.get(['lampid'])].action(**state)
 		else:
 			self.pbridge.lights[self._settings.get(['lampid'])].state(**state)
+
+	def toggle_state(self):
+		if self.get_state():
+			self.set_state({"on": False})
+		else:
+			self.set_state({"on": True})
 
 	def on_after_startup(self):
 		self._logger.info("Octohue is alive!")
@@ -74,8 +88,7 @@ class OctohuePlugin(octoprint.plugin.StartupPlugin,
 	
 	def on_api_command(self, command, data):
 		if command == 'togglehue':
-			self._logger.info("Lights on... Lights off")
-
+			self.toggle_state()
 
 	# State to Light mappings
 	def on_event(self, event, payload):

--- a/octoprint_octohue/__init__.py
+++ b/octoprint_octohue/__init__.py
@@ -4,11 +4,13 @@ from qhue import Bridge, QhueException
 from colormath.color_objects import XYZColor, sRGBColor
 from colormath.color_conversions import convert_color
 import octoprint.plugin
+import flask
 
 
 class OctohuePlugin(octoprint.plugin.StartupPlugin,
 					octoprint.plugin.ShutdownPlugin,
 					octoprint.plugin.SettingsPlugin,
+					octoprint.plugin.SimpleApiPlugin,
                     octoprint.plugin.AssetPlugin,
                     octoprint.plugin.TemplatePlugin,
 					octoprint.plugin.EventHandlerPlugin):
@@ -65,6 +67,16 @@ class OctohuePlugin(octoprint.plugin.StartupPlugin,
 		if self._settings.get(['offonshutdown']) == True:
 			self.set_state({"on": False})
 
+	def get_api_commands(self):
+		return dict(
+			togglehue=[]
+		)
+	
+	def on_api_command(self, command, data):
+		if command == 'togglehue':
+			self._logger.info("Lights on... Lights off")
+
+
 	# State to Light mappings
 	def on_event(self, event, payload):
 		if event == "Connected":
@@ -119,7 +131,8 @@ class OctohuePlugin(octoprint.plugin.StartupPlugin,
 	
 	def get_template_configs(self):
 		return [
-			dict(type="settings", custom_bindings=False)
+			dict(type="settings", custom_bindings=False),
+			dict(type="navbar", custom_bindings=False)
 		]
 
 	##~~ AssetPlugin mixin
@@ -128,9 +141,9 @@ class OctohuePlugin(octoprint.plugin.StartupPlugin,
 		# Define your plugin's asset files to automatically include in the
 		# core UI here.
 		return dict(
-			js=["js/OctoHue.js"],
-			css=["css/OctoHue.css"],
-			less=["less/OctoHue.less"]
+			js=["js/octohue.js"],
+			css=["css/octohue.css"],
+			less=["less/octohue.less"]
 		)
 
 	##~~ Softwareupdate hook

--- a/octoprint_octohue/__init__.py
+++ b/octoprint_octohue/__init__.py
@@ -92,10 +92,10 @@ class OctohuePlugin(octoprint.plugin.StartupPlugin,
 
 	# Trigger state on Status match
 	def on_event(self, event, payload):
-		if event in self._settings.get(["customstatus"]):
+		if event in self._settings.get(["statusDict"]):
 			self._logger.info("Received Event: %s" % event)
-			if self._settings.get(['customstatus'])[event]['turnoff'] == False:
-				self.rgb(self._settings.get(['customstatus'])[event]['colour'],self._settings.get(['customstatus'])[event]['brightness'])
+			if self._settings.get(['statusDict'])[event]['turnoff'] == False:
+				self.rgb(self._settings.get(['statusDict'])[event]['colour'],self._settings.get(['statusDict'])[event]['brightness'])
 			else:
 				self.set_state({"on": False})
 
@@ -110,7 +110,7 @@ class OctohuePlugin(octoprint.plugin.StartupPlugin,
 			defaultbri=255,
 			offonshutdown=True,
 			showhuetoggle=True,
-			customstatus={
+			statusDict={
 				'Connected' : {
 					'colour':'#FFFFFF',
 					'brightness':'255',
@@ -141,12 +141,7 @@ class OctohuePlugin(octoprint.plugin.StartupPlugin,
 					'brightness':'255',
 					'turnoff':False
 				}
-			},
-			connectedc="#FFFFFF",
-			printingc="#FFFFFF",
-			completec="#33FF36",
-			errorc="#FF0000",
-			warningc="#FFC300"
+			}
 		)
 
 	def get_settings_restricted_paths(self):
@@ -161,12 +156,7 @@ class OctohuePlugin(octoprint.plugin.StartupPlugin,
 			defaultbri=self._settings.get(["defaultbri"]),
 			offonshutdown=self._settings.get(["offonshutdown"]),
 			showhuetoggle=self._settings.get(["showhuetoggle"]),
-			customstatus=self._settings.get(["customstatus"]),
-			connectedc=self._settings.get(["connectedc"]),
-			printingc=self._settings.get(["printingc"]),
-			completec=self._settings.get(["completec"]),
-			errorc=self._settings.get(["errorc"]),
-			warningc=self._settings.get(["warningc"])
+			statusDict=self._settings.get(["statusDict"])
 		)
 	
 	def get_template_configs(self):

--- a/octoprint_octohue/__init__.py
+++ b/octoprint_octohue/__init__.py
@@ -71,6 +71,42 @@ class OctohuePlugin(octoprint.plugin.StartupPlugin,
 
 	def on_after_startup(self):
 		self._logger.info("Octohue is alive!")
+		if self._settings.get(["statusDict"]) == '': 
+				self._logger.info("Bootstrapping Octohue Status Defaults")
+				self._settings.set(["statusDict"], {
+					'Connected' : {
+						'colour':'#FFFFFF',
+						'brightness':'255',
+						'turnoff':False
+					},
+					'Disconnected': {
+						'colour':'',
+						'brightness':"",
+						'turnoff':True
+					},
+					'PrintStarted' : {
+						'colour':'#FFFFFF',
+						'brightness':'255',
+						'turnoff':False
+					},
+					'PrintResumed' : {
+						'colour':'#FFFFFF',
+						'brightness':'255',
+						'turnoff':False
+					},
+					'PrintDone': {
+						'colour':'#33FF36',
+						'brightness':'255',
+						'turnoff':False
+					},
+					'PrintFailed':{
+						'colour':'#FF0000',
+						'brightness':'255',
+						'turnoff':False
+					}
+				})
+				self._settings.save()
+
 		self._logger.debug("Bridge Address is %s" % self._settings.get(['bridgeaddr']) if self._settings.get(['bridgeaddr']) else "Please set Bridge Address in settings")
 		self._logger.debug("Hue Username is %s" % self._settings.get(['husername']) if self._settings.get(['husername']) else "Please set Hue Username in settings")
 		self.pbridge = Bridge(self._settings.get(['bridgeaddr']), self._settings.get(['husername']))
@@ -93,7 +129,7 @@ class OctohuePlugin(octoprint.plugin.StartupPlugin,
 	# Trigger state on Status match
 	def on_event(self, event, payload):
 		if event in self._settings.get(["statusDict"]):
-			self._logger.info("Received Event: %s" % event)
+			self._logger.info("Received Status Event: %s" % event)
 			if self._settings.get(['statusDict'])[event]['turnoff'] == False:
 				self.rgb(self._settings.get(['statusDict'])[event]['colour'],self._settings.get(['statusDict'])[event]['brightness'])
 			else:
@@ -110,43 +146,12 @@ class OctohuePlugin(octoprint.plugin.StartupPlugin,
 			defaultbri=255,
 			offonshutdown=True,
 			showhuetoggle=True,
-			statusDict={
-				'Connected' : {
-					'colour':'#FFFFFF',
-					'brightness':'255',
-					'turnoff':False
-				},
-				'Disconnected': {
-					'colour':'',
-					'brightness':"",
-					'turnoff':True
-				},
-				'PrintStarted' : {
-					'colour':'#FFFFFF',
-					'brightness':'255',
-					'turnoff':False
-				},
-				'PrintResumed' : {
-					'colour':'#FFFFFF',
-					'brightness':'255',
-					'turnoff':False
-				},
-				'PrintDone': {
-					'colour':'#33FF36',
-					'brightness':'255',
-					'turnoff':False
-				},
-				'PrintFailed':{
-					'colour':'#FF0000',
-					'brightness':'255',
-					'turnoff':False
-				}
-			}
+			statusDict=""
 		)
 
 	def get_settings_restricted_paths(self):
 		return dict(admin=[["bridgeaddr"],["husername"]])
-
+		
 	def get_template_vars(self):
 		return dict(
 			bridgeaddr=self._settings.get(["bridgeaddr"]),

--- a/octoprint_octohue/__init__.py
+++ b/octoprint_octohue/__init__.py
@@ -29,7 +29,7 @@ class OctohuePlugin(octoprint.plugin.StartupPlugin,
 			green = int(rstring[3:5], 16)
 			blue = int(rstring[5:], 16)
 
-		# We need to convert the RGB value to Yxy.
+		# We need to convert the RGB value to Yxz.
 		redScale = float(red) / 255.0
 		greenScale = float(green) / 255.0
 		blueScale = float(blue) / 255.0
@@ -71,8 +71,8 @@ class OctohuePlugin(octoprint.plugin.StartupPlugin,
 
 	def on_after_startup(self):
 		self._logger.info("Octohue is alive!")
-		self._logger.info("Bridge Address is %s" % self._settings.get(['bridgeaddr']) if self._settings.get(['bridgeaddr']) else "Please set Bridge Address in settings")
-		self._logger.info("Hue Username is %s" % self._settings.get(['husername']) if self._settings.get(['husername']) else "Please set Hue Username in settings")
+		self._logger.debug("Bridge Address is %s" % self._settings.get(['bridgeaddr']) if self._settings.get(['bridgeaddr']) else "Please set Bridge Address in settings")
+		self._logger.debug("Hue Username is %s" % self._settings.get(['husername']) if self._settings.get(['husername']) else "Please set Hue Username in settings")
 		self.pbridge = Bridge(self._settings.get(['bridgeaddr']), self._settings.get(['husername']))
 		self._logger.debug("Bridge established at: %s" % self.pbridge.url)
 
@@ -109,6 +109,8 @@ class OctohuePlugin(octoprint.plugin.StartupPlugin,
 			self._logger.info("Received Event: %s" % event)
 			self.rgb(self._settings.get(["errorc"]))
 
+# General Octoprint Hooks Below
+
 	def get_settings_defaults(self):
 		return dict(
 			bridgeaddr="",
@@ -117,6 +119,7 @@ class OctohuePlugin(octoprint.plugin.StartupPlugin,
 			lampisgroup="",
 			defaultbri="",
 			offonshutdown=True,
+			showhuetoggle=True,
 			connectedc="#FFFFFF",
 			printingc="#FFFFFF",
 			completec="#33FF36",
@@ -135,6 +138,7 @@ class OctohuePlugin(octoprint.plugin.StartupPlugin,
 			lampisgroup=self._settings.get(["lampisgroup"]),
 			defaultbri=self._settings.get(["defaultbri"]),
 			offonshutdown=self._settings.get(["offonshutdown"]),
+			showhuetoggle=self._settings.get(["showhuetoggle"]),
 			connectedc=self._settings.get(["connectedc"]),
 			printingc=self._settings.get(["printingc"]),
 			completec=self._settings.get(["completec"]),
@@ -144,8 +148,7 @@ class OctohuePlugin(octoprint.plugin.StartupPlugin,
 	
 	def get_template_configs(self):
 		return [
-			dict(type="settings", custom_bindings=False),
-			dict(type="navbar", custom_bindings=False)
+			dict(type="settings", custom_bindings=False)
 		]
 
 	##~~ AssetPlugin mixin

--- a/octoprint_octohue/__init__.py
+++ b/octoprint_octohue/__init__.py
@@ -135,7 +135,7 @@ class OctohuePlugin(octoprint.plugin.StartupPlugin,
 			else:
 				self.set_state({"on": False})
 
-# General Octoprint Hooks Below
+	# General Octoprint Hooks Below
 
 	def get_settings_defaults(self):
 		return dict(

--- a/octoprint_octohue/static/js/OctoHue.js
+++ b/octoprint_octohue/static/js/OctoHue.js
@@ -12,7 +12,9 @@ $(function() {
         // self.loginStateViewModel = parameters[0];
         // self.settingsViewModel = parameters[1];
 
-        // TODO: Implement your plugin's view model here.
+        self.togglehue = function() {
+            OctoPrint.simpleApiCommand("octohue", "togglehue", {}, {});
+        };
     }
 
     /* view model class, parameters for constructor, container to bind to
@@ -23,7 +25,8 @@ $(function() {
         construct: OctohueViewModel,
         // ViewModels your plugin depends on, e.g. loginStateViewModel, settingsViewModel, ...
         dependencies: [ /* "loginStateViewModel", "settingsViewModel" */ ],
+        // dependencies: [ NavigationViewModel ],
         // Elements to bind to, e.g. #settings_plugin_OctoHue, #tab_plugin_OctoHue, ...
-        elements: [ /* ... */ ]
+        elements: [ "#navbar_plugin_octohue" ]
     });
 });

--- a/octoprint_octohue/static/js/OctoHue.js
+++ b/octoprint_octohue/static/js/OctoHue.js
@@ -7,17 +7,45 @@
 $(function() {
     function OctohueViewModel(parameters) {
         var self = this;
-      
+  
         self.settingsViewModel = parameters[0];
 
+        self.ownSettings = {}
+        self.customstatus = {}
+
+        self.obsstatus = []
+        
+        self.flattenstatus = function() {
+            for (let ki=0; ki < Object.keys(self.customstatus).length; ki++ ) {
+                self.statusobj = {};
+                self.status = Object.keys(self.customstatus)[ki]
+                self.statusobj.status = self.status
+                for (let [key, value] of Object.entries(self.customstatus[self.status]) ) {
+                    self.statusobj[key] = value
+                }
+                self.obsstatus.push(self.statusobj)
+            }
+        }
+
+        self.addNewStatus = function() {
+            
+        }
         self.togglehue = function() {
             OctoPrint.simpleApiCommand("octohue", "togglehue", {}, {});
-        };
+        }
  
         self.onBeforeBinding = function () {
-            self.settings = self.settingsViewModel.settings.plugins.octohue;
-            // From server-settings to client-settings
-        };
+            self.settings = self.settingsViewModel.settings;
+            self.ownSettings = self.settings.plugins.octohue;
+            self.customstatus = self.ownSettings.customstatus
+
+            self.flattenstatus();
+
+        }
+
+        
+
+
     }
 
     /* view model class, parameters for constructor, container to bind to
@@ -26,7 +54,7 @@ $(function() {
      */
     OCTOPRINT_VIEWMODELS.push({
         construct: OctohueViewModel,
-        dependencies: [ "settingsViewModel" ],
-        elements: [ "#navbar_plugin_octohue" ]
-    });
-});
+        dependencies: ["settingsViewModel"],
+        elements: ["#settings_plugin_octohue", "#navbar_plugin_octohue"]
+    })
+})

--- a/octoprint_octohue/static/js/OctoHue.js
+++ b/octoprint_octohue/static/js/OctoHue.js
@@ -8,10 +8,6 @@ $(function() {
     function OctohueViewModel(parameters) {
         var self = this;
 
-        // assign the injected parameters, e.g.:
-        // self.loginStateViewModel = parameters[0];
-        // self.settingsViewModel = parameters[1];
-
         self.togglehue = function() {
             OctoPrint.simpleApiCommand("octohue", "togglehue", {}, {});
         };
@@ -23,10 +19,7 @@ $(function() {
      */
     OCTOPRINT_VIEWMODELS.push({
         construct: OctohueViewModel,
-        // ViewModels your plugin depends on, e.g. loginStateViewModel, settingsViewModel, ...
         dependencies: [ /* "loginStateViewModel", "settingsViewModel" */ ],
-        // dependencies: [ NavigationViewModel ],
-        // Elements to bind to, e.g. #settings_plugin_OctoHue, #tab_plugin_OctoHue, ...
         elements: [ "#navbar_plugin_octohue" ]
     });
 });

--- a/octoprint_octohue/static/js/OctoHue.js
+++ b/octoprint_octohue/static/js/OctoHue.js
@@ -7,9 +7,16 @@
 $(function() {
     function OctohueViewModel(parameters) {
         var self = this;
+      
+        self.settingsViewModel = parameters[0];
 
         self.togglehue = function() {
             OctoPrint.simpleApiCommand("octohue", "togglehue", {}, {});
+        };
+ 
+        self.onBeforeBinding = function () {
+            self.settings = self.settingsViewModel.settings.plugins.octohue;
+            // From server-settings to client-settings
         };
     }
 
@@ -19,7 +26,7 @@ $(function() {
      */
     OCTOPRINT_VIEWMODELS.push({
         construct: OctohueViewModel,
-        dependencies: [ /* "loginStateViewModel", "settingsViewModel" */ ],
+        dependencies: [ "settingsViewModel" ],
         elements: [ "#navbar_plugin_octohue" ]
     });
 });

--- a/octoprint_octohue/templates/octohue_navbar.jinja2
+++ b/octoprint_octohue/templates/octohue_navbar.jinja2
@@ -1,0 +1,3 @@
+<a title="{{ _('Toggle Light') }}" class="pull-right" href="#" data-bind="click: togglehue">
+    <i class="fa fa-lightbulb-o"></i>
+</a>

--- a/octoprint_octohue/templates/octohue_navbar.jinja2
+++ b/octoprint_octohue/templates/octohue_navbar.jinja2
@@ -1,3 +1,3 @@
-<a title="{{ _('Toggle Light') }}" class="pull-right" href="#" data-bind="click: togglehue, visible: settingsViewModel.settings.plugins.octohue.showhuetoggle">
+<a title="{{ _('Toggle Light') }}" class="pull-right" href="#" data-bind="click: togglehue, visible: ownSettings.showhuetoggle">
     <i class="fa fa-lightbulb-o"></i>
 </a>

--- a/octoprint_octohue/templates/octohue_navbar.jinja2
+++ b/octoprint_octohue/templates/octohue_navbar.jinja2
@@ -1,3 +1,3 @@
-<a title="{{ _('Toggle Light') }}" class="pull-right" href="#" data-bind="click: togglehue">
+<a title="{{ _('Toggle Light') }}" class="pull-right" href="#" data-bind="click: togglehue, visible: settingsViewModel.settings.plugins.octohue.showhuetoggle">
     <i class="fa fa-lightbulb-o"></i>
 </a>

--- a/octoprint_octohue/templates/octohue_settings.jinja2
+++ b/octoprint_octohue/templates/octohue_settings.jinja2
@@ -1,19 +1,19 @@
-  <form class="form-horizontal">
+<form class="form-horizontal">
     <div class="control-group">
         <h4>Hue Configuration</h4>
         <label class="control-label">{{ _('Hue Bridge Address') }}</label>
         <div class="controls">
-            <input type="text" class="input-block-level" data-bind="value: settings.plugins.octohue.bridgeaddr">
+            <input type="text" class="input-block-level" data-bind="value: ownSettings.bridgeaddr">
         </div>
         <label class="control-label">{{ _('Hue Username') }}</label>
         <div class="controls">
-            <input type="text" class="input-block-level" data-bind="value: settings.plugins.octohue.husername">
+            <input type="text" class="input-block-level" data-bind="value: ownSettings.husername">
         </div>
         <label class="control-label">{{ _('Hue Lamp or Group ID') }}</label>
         <div class="controls">
-            <input type="text" class="input-mini" data-bind="value: settings.plugins.octohue.lampid">
+            <input type="text" class="input-mini" data-bind="value: ownSettings.lampid">
             <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octohue.lampisgroup">Use group instead of single lamp
+                    <input type="checkbox" data-bind="checked: ownSettings.lampisgroup">Use group instead of single lamp
             </label>
         </div>
     </div>
@@ -23,45 +23,66 @@
             <label class="control-label"></label>
             <div class="controls">
                 <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octohue.offonshutdown">Lights Off on Server Shutdown
+                    <input type="checkbox" data-bind="checked: ownSettings.offonshutdown">Lights Off on Server Shutdown
                 </label>
             </div>
             <label class="control-label"></label>
             <div class="controls">
                 <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octohue.showhuetoggle">Add Hue Toggle Icon to Navigation Bar
+                    <input type="checkbox" data-bind="checked: ownSettings.showhuetoggle">Add Hue Toggle Icon to Navigation Bar
                 </label>
             </div>
-            <label class="control-label"></label>
+            <label class="control-label">{{ _('Default Brightness') }}</label>
             <div class="controls">
-                <label class="control-label">{{ _('Brightness') }}</label>
-                <div class="controls">
-                    <input type="text" class="input-mini" data-bind="value: settings.plugins.octohue.defaultbri">
-                </div>
+                <input type="text" class="input-mini" data-bind="value: ownSettings.defaultbri">
             </div>
         </div>
     </div> 
     <div class="control-group">
         <h4>Status Colours</h4>
-        <div class="control-group">
-            <label class="control-label">Connected</label>
-            <div class="controls">
-                <input type="color" class="input-mini" data-bind="value: settings.plugins.octohue.connectedc">
-                <input type="text" class="input-mini" data-bind="value: settings.plugins.octohue.connectedc">
-            </div>
-        </div>
-        <div class="control-group">
-            <label class="control-label">Print Completed</label>
-            <div class="controls">
-                <input type="color" class="input-mini" data-bind="value: settings.plugins.octohue.completec">
-                <input type="text" class="input-mini" data-bind="value: settings.plugins.octohue.completec">
-            </div>
-        </div>
-        <div class="control-group">
-            <label class="control-label">Print Error</label>
-            <div class="controls">
-                <input type="color" class="input-mini" data-bind="value: settings.plugins.octohue.errorc">
-                <input type="text" class="input-mini" data-bind="value: settings.plugins.octohue.errorc">
+        <div style="margin-left: 25px">
+            <table class="table table-striped table-condensed">
+                <thead>
+                    <tr>
+                        <th>
+                            Status
+                        </th>
+                        <th>
+                            Colour
+                        </th>
+                        <th>
+                            Hex
+                        </th>
+                        <th>
+                            Brightness
+                        </th>
+                        <th>
+                            Or Switch Off
+                        </th>
+                    </tr>
+                </thead>
+                <tbody class="control-group" data-bind="foreach: obsstatus">
+                    <tr>
+                        <td>
+                            <input type="text" value="Status" data-bind="value: status">
+                        </td>
+                        <td>
+                            <input type="color" class="input-mini" data-bind="value: colour">
+                        </td>
+                        <td>
+                            <input type="text" class="input-mini" data-bind="value: colour">
+                        </td>
+                        <td>
+                            <input type="text" class="input-mini" data-bind="value: brightness">
+                        </td>
+                        <td>
+                            <input type="checkbox" data-bind="checked: turnoff">
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+            <div class="control">
+                <button class="btn" data-bind="click: addNewStatus">New</button>
             </div>
         </div>
     </div>

--- a/octoprint_octohue/templates/octohue_settings.jinja2
+++ b/octoprint_octohue/templates/octohue_settings.jinja2
@@ -61,7 +61,7 @@
                         </th>
                     </tr>
                 </thead>
-                <tbody class="control-group" data-bind="foreach: obsstatus">
+                <tbody class="control-group" data-bind="foreach: flatStatus">
                     <tr>
                         <td>
                             <input type="text" value="Status" data-bind="value: status">
@@ -76,7 +76,10 @@
                             <input type="text" class="input-mini" data-bind="value: brightness">
                         </td>
                         <td>
-                            <input type="checkbox" data-bind="checked: turnoff">
+                            <i data-bind="attr: { class: turnoff() ? 'fa fa-check-square-o' : 'fa fa-square-o' }, click: $parent.setSwitchOff"></i>
+                        </td>
+                        <td>
+                            <i class="fa fa-trash-o" data-bind="click: $parent.onStatusDictDelete"></i>
                         </td>
                     </tr>
                 </tbody>

--- a/octoprint_octohue/templates/octohue_settings.jinja2
+++ b/octoprint_octohue/templates/octohue_settings.jinja2
@@ -26,6 +26,13 @@
                     <input type="checkbox" data-bind="checked: settings.plugins.octohue.offonshutdown">Lights Off on Server Shutdown
                 </label>
             </div>
+            <label class="control-label"></label>
+            <div class="controls">
+                <label class="checkbox">
+                    <input type="checkbox" data-bind="checked: settings.plugins.octohue.showhuetoggle">Add Hue Toggle Icon to Navigation Bar
+                </label>
+            </div>
+            <label class="control-label"></label>
             <div class="controls">
                 <label class="control-label">{{ _('Brightness') }}</label>
                 <div class="controls">


### PR DESCRIPTION
Added features:
- Settings allow user to add a light toggle option to the navbar
- Complete user configurable status list.
- Added "Off" as a status option

**User Configurable Statuses**
Re-worked Status configuration to allow complete user customisability. 
Previously I stored a seperate settings key to hold each statuses colour and brightness, triggered against a predetermined set of statuses.
Now the settings contains statusDict, whose keys match the statuses the users is interested in, the value of which is a nested dict containing colour, brightness, and if the light should be extinguished.

To avoid some quirks of Octoprints settings persistence, if no statuses are defined in statusDict, the default statuses in statusDict are bootstrapped into settings on plugin start so that they are then persisted to yaml.