### PR TITLE
Fix OctoPrint 1.13.0 autoescape warning

### DIFF
--- a/octoprint_octohue/__init__.py
+++ b/octoprint_octohue/__init__.py
@@ -824,6 +824,9 @@ class OctohuePlugin(octoprint.plugin.StartupPlugin,
 			statusDict=self._settings.get(["statusDict"])
 		)
 
+	def is_template_autoescaped(self):
+		return True
+
 	def get_template_configs(self):
 		'''
 		Declares a custom-bound settings panel.


### PR DESCRIPTION
Overrides `is_template_autoescaped()` to return `True`, opting in to Jinja2 autoescaping ahead of it becoming mandatory in OctoPrint 1.13.0. Confirmed via local OctoPrint instance — warning no longer appears in logs.