### PR TITLE
Release 1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+---
+
+## [1.0.4] - 2026-04-05
+
 ### Added
 - `CLAUDE.md` — project context file for [Claude Code](https://claude.ai/code); documents project structure, test commands, branching workflow, release channels, and Hue v2 API conventions
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "OctoHue"
-version = "1.0.3"
+version = "1.0.4"
 description = "Illuminate your printer and signal its status using Phillips Hue lights"
 authors = [
     { name = "Simon Beckett", email = "sirsimonbeckett@gmail.com" },


### PR DESCRIPTION
Version bump and CHANGELOG for 1.0.4.

- CLAUDE.md project context file
- OctoPrint 1.13.0 autoescape fix (verified against local OctoPrint 1.11.7 instance)