### PR TITLE
Fix empty colour_hex crash in WledProvider

### DIFF
--- a/octoprint_octohue/providers/wled.py
+++ b/octoprint_octohue/providers/wled.py
@@ -150,7 +150,7 @@ class WledProvider(LightProvider):
 
             if ct_mirek is not None:
                 seg["cct"] = _mirek_to_wled_cct(ct_mirek)
-            elif colour_hex is not None:
+            elif colour_hex:
                 r, g, b = _hex_to_rgb(colour_hex)
                 seg["col"] = [[r, g, b]]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,6 +176,7 @@ def make_settings_getter(overrides=None):
         "showhuetoggle": True,
         "showpowertoggle": False,
         "statusDict": [],
+        "nightmode_enabled": False,
     }
     if overrides:
         defaults.update(overrides)


### PR DESCRIPTION
Cherry-pick of fc79177 — guards colour_hex with a truthiness check to prevent ValueError in _hex_to_rgb when the colour setting is an empty string. Also adds nightmode_enabled=False to test defaults.